### PR TITLE
Refactor: replace strapi client with axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@strapi/client": "^1.3.0",
     "axios": "^1.9.0",
     "next": "15.3.1",
     "react": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@strapi/client':
-        specifier: ^1.3.0
-        version: 1.3.0
       axios:
         specifier: ^1.9.0
         version: 1.9.0
@@ -313,10 +310,6 @@ packages:
 
   '@rushstack/eslint-patch@1.11.0':
     resolution: {integrity: sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==}
-
-  '@strapi/client@1.3.0':
-    resolution: {integrity: sha512-qRssxOR+vOrDZDLpugDoZyLYJw2nZjDgTQttddAPgbqhdt+elf+zW1NZW7uEbTY9yIpTokw/FSq+2lJ2qVDHaA==}
-    engines: {node: '>=20.18.2 <=22.x.x'}
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -1491,10 +1484,6 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
-    engines: {node: '>=0.6'}
-
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -1974,13 +1963,6 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.11.0': {}
-
-  '@strapi/client@1.3.0':
-    dependencies:
-      debug: 4.4.0
-      qs: 6.14.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@swc/counter@0.1.3': {}
 
@@ -3300,10 +3282,6 @@ snapshots:
   proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
-
-  qs@6.14.0:
-    dependencies:
-      side-channel: 1.1.0
 
   queue-microtask@1.2.3: {}
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,19 +1,18 @@
-import { strapiClient } from "@/lib/api-client";
+import { StrapiClient } from "@/lib/api-client";
+import { Post } from "@/lib/types";
 import { revalidatePath } from "next/cache";
 import Link from "next/link";
 
-const postCollection = strapiClient.collection("posts");
+const postCollection = new StrapiClient<Post>("posts");
 
 export default async function Home() {
-  const posts = await postCollection.find({
-    sort: "createdAt:desc",
-  });
+  const posts = await postCollection.findAll({ sort: "createdAt:desc" });
 
   async function create(formData: FormData) {
     "use server";
 
     await postCollection.create({
-      content: formData.get("content"),
+      content: formData.get("content")?.toString() ?? "",
     });
 
     revalidatePath("/");
@@ -23,7 +22,9 @@ export default async function Home() {
 
     const documentId = formData.get("post-id");
 
-    await postCollection.delete(documentId?.toString() ?? "");
+    await postCollection.delete({
+      id: documentId?.toString() ?? "",
+    });
 
     revalidatePath("/");
   }
@@ -56,7 +57,7 @@ export default async function Home() {
         </form>
       </div>
       <div>
-        {posts.data?.map((post) => (
+        {posts.map((post) => (
           <div
             key={post.documentId}
             className="p-4 mb-3 bg-gray-100 border border-gray-300 rounded shadow-sm flex flex-col gap-3"

--- a/src/app/post/[id]/edit/page.tsx
+++ b/src/app/post/[id]/edit/page.tsx
@@ -1,23 +1,24 @@
-import { strapiClient } from "@/lib/api-client";
+import { StrapiClient } from "@/lib/api-client";
+import { Post } from "@/lib/types";
 import { redirect, RedirectType } from "next/navigation";
 
 type Props = {
   params: { id: string };
 };
 
-const postCollection = strapiClient.collection("posts");
+const postCollection = new StrapiClient<Post>("posts");
 
 export default async function Page({ params }: Props) {
   const { id } = await params;
 
-  const post = await postCollection.findOne(id);
+  const post = await postCollection.find(id);
 
   async function edit(formData: FormData) {
     "use server";
 
     await postCollection
       .update(formData.get("post-id")?.toString() ?? "", {
-        content: formData.get("content"),
+        content: formData.get("content")?.toString() ?? "",
       })
       .catch((error) => {
         console.error(error);
@@ -30,7 +31,7 @@ export default async function Page({ params }: Props) {
   return (
     <div>
       <h1>{id}</h1>
-      <h2>{post.data.createdAt}</h2>
+      <h2>{post.createdAt}</h2>
       <form
         action={edit}
         className="p-4 max-w-md mx-auto bg-gray-100 rounded shadow"
@@ -43,7 +44,7 @@ export default async function Page({ params }: Props) {
             id="post-id"
             name="post-id"
             type="text"
-            defaultValue={post.data.documentId}
+            defaultValue={post.documentId}
             hidden
           />
           <input
@@ -52,7 +53,7 @@ export default async function Page({ params }: Props) {
             name="content"
             id="content"
             placeholder="Type something..."
-            defaultValue={post.data.content}
+            defaultValue={post.content}
           />
         </label>
         <button

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,14 +1,61 @@
-import { strapi } from "@strapi/client";
+import axios, { AxiosInstance } from "axios";
 import { removeTrailingSlash } from "./utils";
 
-const API_BASE_URL = removeTrailingSlash(
-  process.env.CMS_BASE_URL ?? "http://localhost:1337/api"
-);
+export class StrapiClient<T> {
+  private axiosInstance: AxiosInstance;
+  private collectionName: string;
 
-function createApiClient(baseURL: string) {
-  return strapi({
-    baseURL,
-  });
+  constructor(collectionName: string) {
+    this.axiosInstance = axios.create({
+      baseURL: removeTrailingSlash(
+        process.env.CMS_BASE_URL ?? "http://localhost:1337/api"
+      ),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    this.collectionName = collectionName;
+  }
+
+  async findAll(params?: Record<string, any>): Promise<T[]> {
+    const url = `/${this.collectionName}`;
+    const response = await this.axiosInstance.get<{ data: T[] }>(url, {
+      params,
+    });
+
+    return response.data.data;
+  }
+
+  async find(id: string, params?: Record<string, any>): Promise<T> {
+    const url = `/${this.collectionName}/${id}`;
+    const response = await this.axiosInstance.get<{ data: T }>(url, {
+      params,
+    });
+
+    return response.data.data;
+  }
+
+  async create(data: T): Promise<T> {
+    const response = await this.axiosInstance.post<{ data: T }>(
+      `/${this.collectionName}`,
+      {
+        data,
+      }
+    );
+    return response.data.data;
+  }
+
+  async update(documentId: string, data: Partial<T>): Promise<T> {
+    const response = await this.axiosInstance.put<{ data: T }>(
+      `/${this.collectionName}/${documentId}`,
+      {
+        data,
+      }
+    );
+    return response.data.data;
+  }
+
+  async delete(query: { id: string }): Promise<void> {
+    await this.axiosInstance.delete(`/${this.collectionName}/${query.id}`);
+  }
 }
-
-export const strapiClient = createApiClient(API_BASE_URL || "");

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,8 @@
+export type Post = {
+  content: string;
+  id?: number;
+  documentId?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  publishedAt?: string;
+};


### PR DESCRIPTION
This removes strapi client and replace it with simple axios client instance. This was made as the strapi client library does not work with authentication.